### PR TITLE
Correction du CMakeFile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 project (Kiwi)
 cmake_minimum_required (VERSION 2.4) 
 
-set(BUILD_KIWI_TESTS "yes")
+#set(BUILD_KIWI_TESTS "yes")
 set(BUILD_KIWI_IMAGE "yes")
 set(BUILD_KIWI_TEXT "yes")
 set(BUILD_KIWI_CMDLINE "yes")
@@ -55,6 +55,12 @@ FIND_PACKAGE(Boost REQUIRED)
 if ( Boost_FOUND )
    message( "-- Boost found. include=${Boost_INCLUDE_DIR}" )
    include_directories( ${Boost_INCLUDE_DIR} )
+
+
+   if(DEFINED APPLE) 
+     message( "-- Apple plateform detected : Boost lib path added." )
+     link_directories(/opt/local/lib)
+   endif(DEFINED APPLE)
 endif ( Boost_FOUND )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,13 +56,17 @@ if ( Boost_FOUND )
    message( "-- Boost found. include=${Boost_INCLUDE_DIR}" )
    include_directories( ${Boost_INCLUDE_DIR} )
 
+if(DEFINED APPLE AND NOT DEFINED ${MACPORT_BOOST_FOUND})
+	SET( MACPORT_BOOST_INCLUDES "/opt/local/includes/boost")	
+	SET( MACPORT_BOOST_LIBS "/opt/local/libs/")	
 
-   if(DEFINED APPLE) 
-     message( "-- Apple plateform detected : Boost lib path added." )
-     link_directories(/opt/local/lib)
-   endif(DEFINED APPLE)
+   	include_directories( ${MACPORT_BOOST_INCLUDES} )
+   	link_directories( ${MACPORT_BOOST_LIBS} )
+	set( MACPORT_BOOST_FOUND TRUE) 	
+     	
+	message( "-- Apple plateform detected : Boost lib path added." )
+endif(DEFINED APPLE AND NOT DEFINED MACPORT_BOOST_FOUND)
 endif ( Boost_FOUND )
-
 
 if(DEFINED BUILD_KIWI_IMAGE)
 	find_package(Cairo REQUIRED)


### PR DESCRIPTION
Le CMakefile n'était jusqu'alors pas compatible avec les plateforme Mac car les répertoire includes/ et libs/ n'étaient pas les même que sur Linux.

J'ai corrigé le CMakefile et assuré la compatibilité avec snowLeopard/MacPort. Il faudrait éventuellement ajouter des trucs pour les utilisateurs de fink. A voir.

Bisouxx !
